### PR TITLE
Use DATE_ATOM instead of DATE_ISO8601 (not ISO8601 compatible)

### DIFF
--- a/Classes/Types/Scalars/DateTime.php
+++ b/Classes/Types/Scalars/DateTime.php
@@ -39,7 +39,7 @@ class DateTime extends ScalarType
         if (!$value instanceof \DateTimeInterface) {
             return null;
         }
-        return $value->format(DATE_ISO8601);
+        return $value->format(DATE_ATOM);
     }
 
     /**
@@ -51,7 +51,7 @@ class DateTime extends ScalarType
         if (!is_string($value)) {
             return null;
         }
-        $dateTime = \DateTimeImmutable::createFromFormat(DATE_ISO8601, $value);
+        $dateTime = \DateTimeImmutable::createFromFormat(DATE_ATOM, $value);
         if ($dateTime === false) {
             return null;
         }


### PR DESCRIPTION
The PHP documentation recommends using DATE_ATOM instead of DATE_ISO8601. Since the second one is not compatible with ISO-8601. Check: http://php.net/manual/en/class.datetime.php#datetime.constants.iso860