### PR TITLE
TASK: Allow Neos 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "name": "wwwision/neos-graphql",
     "license": "GPL-3.0+",
     "require": {
-        "neos/neos": "^4.2 || ^5.0 || ^5.1",
-        "wwwision/graphql": "^3.1"
+        "neos/neos": "^4.2 || ^5.0 || ^5.1 || ^7.0",
+        "wwwision/graphql": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I've increased the required version for `wwwision/graphql` to `^4.0` and added NEOS 7.x as a requirement to make it usable for 7.x.